### PR TITLE
Add more details about the PAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # MDN Web Docs Product Advisory Board
 
-This is the GitHub repo for the MDN Web Docs Product Advisory Board (MDN PAB).
+This is the GitHub repo for the [MDN Web Docs](https://developer.mozilla.org/) [Product Advisory Board](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board) (MDN PAB). The PAB is a collaborative group of tech organizations and leaders who together advise and make suggestions for the future of MDN, as well as, in many cases, make direct contributions to MDN's code or content.
+
+## Meetings
 
 You can find notes from our meetings in the [meeting-notes](meeting-notes) directory.
+
+# Other links
+
+* [PAB Charter & Membership](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Membership)
+* [Current PAB Members](https://developer.mozilla.org/en-US/docs/MDN/MDN_Product_Advisory_Board/Members)
+* [PAB Membership Application](https://www.dropbox.com/s/noj6vddhumhe9o0/MDN%20Product%20Advisory%20Board%20Interest%20Form.pdf?dl=0)


### PR DESCRIPTION
Added more details about what the PAB is, as well as links to the pages on MDN about the PAB, its members, and the membership application. Also added a link directly to MDN.